### PR TITLE
fix: mac failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: ruby setup (mac)
-        if: ${{ matrix.os }} == 'macOS-latest'
+        if: matrix.os == 'macOS-latest'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ jobs:
         family: [tiny, normal, huge]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: ruby setup (mac)
+        if: ${{ matrix.os }} == 'macOS-latest'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
       - name: asdf plugin test
         uses: asdf-vm/actions/plugin-test@v1
         env:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,6 +11,11 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: ruby setup (mac)
+        if: ${{ matrix.os }} == 'macOS-latest'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
       - name: asdf plugin test
         uses: asdf-vm/actions/plugin-test@v1
         env:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: ruby setup (mac)
-        if: ${{ matrix.os }} == 'macOS-latest'
+        if: matrix.os == 'macOS-latest'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# asdf-vim ![GitHub Actions Status:Commit](https://github.com/tsuyoshicho/asdf-vim/workflows/Commit%20workflow/badge.svg) ![GitHub Actions Status:Schedule](https://github.com/tsuyoshicho/asdf-vim/workflows/Schedule%20workflow/badge.svg)
+# asdf-vim [![GitHub Actions Status:Commit](https://github.com/tsuyoshicho/asdf-vim/workflows/Commit%20workflow/badge.svg)](https://github.com/tsuyoshicho/asdf-vim/actions?query=workflow%3A%22Commit+workflow%22) [![GitHub Actions Status:Schedule](https://github.com/tsuyoshicho/asdf-vim/workflows/Schedule%20workflow/badge.svg)](https://github.com/tsuyoshicho/asdf-vim/actions?query=workflow%3A%22Schedule+workflow%22)
 
 Vim plugin for [asdf](https://github.com/asdf-vm/asdf) version manager.
 


### PR DESCRIPTION
# about

Fix below issue related problem.

see: https://github.com/actions/virtual-environments/issues/1775

- Update macos-latest image
- Ruby update 2.6 to 2.7
- Build failed for 2.7

## resolve

This test need sample env build pass check.
Fix it add setup-ruby at ruby 2.6 for workflow.

ruby 2.7 failed related vim configure problem. stay tune.