### PR TITLE
fix: concurrency do not defined

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,9 @@ install_vim() {
   local concurrency
   version=$1
   install_path=$2
-  concurrency=$3
+  concurrency=$(get_valid_concurrency "$3")
+
+  echo "Install Vim version:${version}, path:${install_path}, build concurrency:${concurrency}"
 
   local default_config="\
 --with-tlib=ncurses \
@@ -98,4 +100,18 @@ get_download_url() {
   return
 }
 
-install_vim "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}" "${ASDF_CONCURRENCY}"
+get_valid_concurrency() {
+  local concurrency
+  concurrency=$1
+
+  if [[ "${concurrency}" =~ ^[0-9]+$ ]]; then
+    # number
+    echo "${concurrency}"
+  else
+    # is not number
+    echo "1"
+  fi
+  return
+}
+
+install_vim "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}" "${ASDF_CONCURRENCY:-1}"


### PR DESCRIPTION
Close #16 

Fix below problem:

* Make the asdf test suite tolerant to returning an incorrect number of parallelisms
* Report building params

(Because asdf seems to be an implementation that normalizes the value of `ASDF_CONCURRENCY` and passes it to the plugin)

https://github.com/asdf-vm/asdf/blob/684f4f058f24cc418f77825a59a22bacd16a9bee/lib/commands/command-install.bash#L9
```bash
install_command "$@"
```

https://github.com/asdf-vm/asdf/blob/684f4f058f24cc418f77825a59a22bacd16a9bee/lib/functions/installs.bash#L13
```bash
install_command() {
```

some pattern call below

https://github.com/asdf-vm/asdf/blob/684f4f058f24cc418f77825a59a22bacd16a9bee/lib/functions/installs.bash#L27
```bash
get_concurrency() {
```

doc
https://github.com/asdf-vm/asdf/blob/master/docs/plugins/create.md
```text
ASDF_CONCURRENCY

the number of cores to use when compiling the source code. Useful for setting make -j
```