### PR TITLE
Improve version sorting and fix regex

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
+# Adapted from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
+function sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
 # Fetch all tag names, and get only second column. Then remove all unnecessary characters.
 list_of_versions=$(
-  git ls-remote --heads --sort=version:refname --tags https://github.com/vim/vim.git \
-  | awk '!/({})/ {print $2}' | awk 'gsub("(refs/tags/)|(v)", "")'
+  git ls-remote --heads --tags https://github.com/vim/vim.git \
+  | awk '!/([{][}])/ {print $2}' | awk 'gsub("(refs/tags/)|(v)", "")' \
+  | sort_versions
 )
 
 echo $list_of_versions


### PR DESCRIPTION
Changes included:
1.  Version sorting at the moment considers 9.1.0 to be the newest version of vim - that's because the output from the git sorting does not sort versions correctly. Following the example of asdf-cmake, I have added a little bit of code to sort versions properly, so that 9.1.0090 is considered newer than 9.1.0 - and so that 9.1.0001 to 9.1.0090 come after 9.1.0. The source was https://github.com/srivathsanmurali/asdf-cmake/blob/master/bin/list-all
2. The regex used in `awk '!/({})/ {print $2}'` works fine in macOS but gives an error in Ubuntu. By adding [] around each { it now works as expected in ubuntu.